### PR TITLE
ISHML.Rule.snip() no longer automatically clones the rule argument. 

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -68,6 +68,7 @@
                             </div>
                             <strong>Methods</strong>
                             <div class="ml-3">
+                                <a class="d-block" href="#rule-clone">clone()</a>
                                 <a class="d-block" href="#rule-configure">configure()</a>
                                 <a class="d-block" href="#rule-parse">parse()</a>
                                 <a class="d-block" href="#rule-snip">snip()</a>
@@ -280,7 +281,8 @@
                         <p class="card-text">Checks the rule's generated syntax tree for semantic correctness and optionally edit the syntax tree.  Defaults to <code>(interpretation)=>true</code>, which accepts all interpretations as semantically correct. Returning <code>false</code> removes the <a href="#interpretation">interpretation</a> from further consideration.  Returning <code>true</code> allows the interperation to continue processing.  Optionally, you may alter the content <code>interpretation.gist</code> and return the altered interpretation as alternative to returning <code>true</code>.</p>  
                         
                         <h2 class="card-title">Methods</h2>
-                        
+                        <h3 class="card-subtitle" id="rule-clone"><code><b>.clone()</b></code></h3>
+                        <p class="card-text">Creates a deep copy of the rule.</p>
                         <h3 class="card-subtitle" id="rule-configure"><code><b>.configure(<i>options</i>)</b></code></h3>
                         <p class="card-text">Configures behavior of rule.</p>
                         <p class="card-text">The <i>options</i> argument is a plain javaScript object with properties that are the same as the <a href="#rule-non-enum"> non-enumerable properties of <code>ISHML.Rule</code></a>.</p>
@@ -294,7 +296,9 @@
                         <h3 class="card-subtitle" id="rule-snip"><code><b>.snip(<i>key</i> [, <i>rule</i>])</b></code></h3>
                         <p class="card-text">Creates a new <code>ISHML.rule</code> instance as an enumerable property of the rule.</p>
                         <p class="card-text">The <i>key</i> argument is the name to be used for the sub-rule and may be a string or integer. If the sub-rule is to be accessed using dot notation, the requirements for dot notation must be observed when naming the key.  For convenience, spaces are automatically converted to underscores.</p>
-                        <p class="card-text">The <i>rule</i> argument is the <code>ISHML.Rule</code> instance to be cloned and assined to the new property. If <i>rule</i> is omitted, a new instance of <code>ISHML.Rule</code> is used.  
+                        <p class="card-text">The <i>rule</i> argument is the <code>ISHML.Rule</code> instance to be assigned to the new property. Cloning of <i>rule</i> is recommended, for example, <code>command.snip("subject",nounPhrase.clone())</code>, unless the rule is being defined recursively.</p>
+                        <p>If <i>rule</i> is omitted, a new instance of <code>ISHML.Rule</code> is used.</p>
+                       
                         <p class="card-text">Returns the rule. This method is chainable.</p>
 
                         <p>See also <a href="parsing.html">parsing tutorial</a>.</p>

--- a/docs/cloakofdarkness.html
+++ b/docs/cloakofdarkness.html
@@ -1,0 +1,559 @@
+<html>
+    <body>
+        
+        <script src="ishml46.js">//should be jsDelIver CDN</script>
+        <script>
+var story= new ISHML.Yarn()
+var net=story.net
+var plot=story.plot
+var storyline=story.storyline
+var grammar=story.grammar
+var lexicon=story.lexicon
+
+lexicon
+    .register("the","a","an").as({kind:"noise"})
+    .register("says").as({key:"says",kind:"tie",part:"relation"})
+    .register("is said by").as({key:"is said by",kind:"tie",part:"relation"})
+    .register("means").as({key:"means",kind:"tie",part:"relation"})
+    .register("is meant by").as({key:"is meant by",kind:"tie",part:"relation"})
+    .register("north", "north of", "n").as({key:"north",kind:"tie",part:"relation"})
+    .register("south", "south of", "s").as({key:"south",kind:"tie",part:"relation"})
+    .register("east", "east of", "e").as({key:"east",kind:"tie",part:"relation"})
+    .register("west", "west of", "w").as({key:"west",kind:"tie",part:"relation"})
+    .register("contains").as({key:"contains",kind:"tie",part:"relation"})
+    .register("is in","in").as({key:"in",kind:"tie",part:"relation"})
+    .register("wears").as({key:"wears",kind:"tie",part:"relation"})
+    .register("is worn by","worn","worn by").as({key:"is worn by",kind:"tie",part:"relation"})
+
+
+grammar.nounPhrase=ISHML.Rule()
+grammar.nounPhrase.article=ISHML.Rule({minimum:0})
+grammar.nounPhrase.article.filter=(definition)=>definition.kind==="noise"
+grammar.nounPhrase.adjectives=ISHML.Rule({minimum:0, maximum:5})
+grammar.nounPhrase.adjectives.filter=(definition)=>(definition.kind==="tie" || definition.kind==="knot")&& definition.part==="adjective"
+grammar.nounPhrase.noun=ISHML.Rule()
+grammar.nounPhrase.noun.filter=(definition)=>definition.kind==="knot" && definition.part==="noun"
+
+grammar.input=ISHML.Rule()
+grammar.input.command=[]
+grammar.input.command[0]=ISHML.Rule()
+grammar.input.command[0].subject=ISHML.Rule({minimum:0})
+grammar.input.command[0].subject.nounPhrase=grammar.nounPhrase
+grammar.input.command[0].subject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[0].subject.adjunct.relation=ISHML.Rule()
+grammar.input.command[0].subject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[0].subject.adjunct.nounPhrase=grammar.nounPhrase
+grammar.input.command[0].verb=ISHML.Rule()
+grammar.input.command[0].verb.filter=(definition)=>definition.kind==="plotpoint"
+grammar.input.command[0].directObject=ISHML.Rule({minimum:0})
+grammar.input.command[0].directObject.nounPhrase=grammar.nounPhrase
+grammar.input.command[0].directObject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[0].directObject.adjunct.relation=ISHML.Rule()
+grammar.input.command[0].directObject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[0].indirectObject=ISHML.Rule({minimum:0})
+grammar.input.command[0].indirectObject.preposition=ISHML.Rule({minimum:1})
+grammar.input.command[0].indirectObject.preposition.filter=(definition)=>definition.kind==="plotpoint" && definition.part==="preposition"
+grammar.input.command[0].indirectObject.nounPhrase=grammar.nounPhrase
+grammar.input.command[0].indirectObject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[0].indirectObject.adjunct.relation=ISHML.Rule()
+grammar.input.command[0].indirectObject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[0].indirectObject.adjunct.nounPhrase=grammar.nounPhrase
+grammar.input.command[1]=ISHML.Rule()
+grammar.input.command[1].subject=ISHML.Rule({minimum:0})
+grammar.input.command[1].subject.nounPhrase=grammar.nounPhrase
+grammar.input.command[1].subject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[1].subject.adjunct.relation=ISHML.Rule()
+grammar.input.command[1].subject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[1].verb=ISHML.Rule()
+grammar.input.command[1].verb.filter=(definition)=>definition.kind==="plotpoint"
+grammar.input.command[1].indirectObject=ISHML.Rule()
+grammar.input.command[1].indirectObject.nounPhrase=grammar.nounPhrase
+grammar.input.command[1].indirectObject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[1].indirectObject.adjunct.relation=ISHML.Rule()
+grammar.input.command[1].indirectObject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[1].indirectObject.adjunct.nounPhrase=grammar.nounPhrase
+grammar.input.command[1].directObject=ISHML.Rule()
+grammar.input.command[1].directObject.nounPhrase=grammar.nounPhrase
+grammar.input.command[1].directObject.adjunct=ISHML.Rule({minimum:0,maximum:5})
+grammar.input.command[1].directObject.adjunct.relation=ISHML.Rule()
+grammar.input.command[1].directObject.adjunct.relation.filter=(definition)=>definition.kind==="tie" && definition.part==="relation"
+grammar.input.command[1].directObject.adjunct.nounPhrase=grammar.nounPhrase
+
+net.knot("player",{name:"You",description:"You are a wery traveler glad to be out of the rain.",score:0})
+net.player.pronoun="you"
+net.player.possessive="your"
+net.knot("ISHML input",{})
+net.knot("ISHML interpretations")
+
+net.player.tie("says").to("ISHML input").conversely("is said by")
+
+net.ISHML_input.tie("means").to("ISHML interpretations").conversely("is meant by")
+
+net.knot("foyer",{
+	name:`Foyer of the Opera House`,
+	description:`You are standing in a spacious hall, splendidly decorated in red and gold, with glittering chandeliers overhead.  
+The entrance from the street is to the north, and there are doorways south and west.`})
+    .label("room")
+    .understand("foyer").as()
+
+net.knot("cloakroom",{
+	name:`Cloakroom`,
+	description:`The walls of this small room were clearly once lined with hooks, though now only one remains.
+The exit is a door to the east.`})
+    .label("room")
+.understand("cloakroom").as()
+
+net.knot("bar",{
+	name:`Foyer Bar`,
+	description:`The bar, much rougher than you'd have guessed after the opulence of the foyer to the north, is completely empty.
+There seems to be some sort of message scrawled in the sawdust on the floor.`})
+    .label("room")
+    .understand("bar","tavern", "foyer bar").as()
+
+/*net.foyer
+    .tie("south")
+    .cord({name:`door`,description: `wooden door`},"portal","closed","locked")
+    .as({description:`green`})
+    .to("bar")
+    .conversely("north")
+    .as({description:`red`})
+    .tie("west").to("cloakroom").conversely("east")
+*/
+
+net.foyer
+    .tie("south")
+    .to("bar")
+    .conversely("north")
+    .tie("west").to("cloakroom").conversely("east")
+
+net.cloakroom
+    .tie("contains").to("hook").conversely("in")
+
+net.hook.understand("small","brass","hook","peg")
+net.hook.label("fixed","hanger")  //fixed in place; can't be moved and you can hang things on it.
+net.hook.name=`hook`
+net.hook.description=`a small brass hook`
+
+net.player.tie("in").to("foyer").conversely("contains")
+net.player.tie("wears").to("cloak").conversely("is worn by")
+
+net.cloak.understand("cloak").as()
+net.cloak.understand("dark","black", "velvet").as({part:"adjective"})
+net.cloak.understand("cloaks").as({part:"noun", number:"plural"})
+
+net.cloak.label("portable","wearable")
+
+plot.add("main")
+plot.main.add("parse")
+plot.main.add("report") 
+plot.main.add("act")		
+
+plot.parse.add("disambiguate")
+plot.parse.add("process")
+plot.process.add("command")
+plot.act.add("action_go").understand("go","go to").as()
+
+plot.act.add("action_north").understand("north","n","go north").as()
+plot.act.add("action_south").understand("south","s").as()
+plot.act.add("action_east").understand("east","e").as()
+plot.act.add("action_west").understand("west","w").as()
+plot.act.add("action_drop").understand("drop","d").as()
+plot.act.add("action_take").understand("take","t").as()
+plot.act.add("action_hang").understand("hang","hang up").as()
+plot.act.add("action_look").understand("look","l").as()
+plot.act.add("action_examine").understand("examine","x").as()
+plot.act.add("action_read").understand("read","peruse").as()
+
+plot.add("examples")
+plot.examples.add("heed")
+plot.heed.narrate=function()
+{
+    this.heed("#command").then((input) =>
+    {
+       this.yarn.say(`<p>I heed your words: ${input.text}</p>`).last("#story") 
+    })
+    return true
+}
+plot.parse.narrate=function(twist)
+{
+	console.log("parse")
+  var {input}=twist  
+  if (input)
+  {
+    this.yarn.net.ISHML_input.$=input
+    return this.plot.narrate(this.yarn.interpret(input))
+  }
+}
+plot.process.narrate=function(twist)
+{
+	console.log("process")
+    var {interpretations,agent}=twist
+    console.log(interpretations,agent)
+    //if current plotline item is input from the user then a truthy value is returned for the situation.
+   if (  interpretations && interpretations.length===1)
+   {
+//	console.log(Object.assign({agent:agent},interpretations[0].gist))
+	   return this.plot.narrate(Object.assign({agent:agent},interpretations[0].gist))
+	   
+   }
+   else return false
+}
+
+plot.command.narrate=function(twist)
+{   
+	console.log("command")
+    var {command,agent}=twist
+    var act={}
+    if (command)
+    {
+        //var action=command.action.definitions[0].key
+        var {subject, verb, directObject,indirectObject}=command
+	
+	if (subject)
+        {
+            act.subject=ISHML.Mesh(this.yarn).add(...subject.nounPhrase.noun.definitions.map(({knot})=>knot))
+            
+            var adjectives=subject.nounPhrase.adjectives
+            if (adjectives)
+            {
+                var definitions=[].concat([],...adjectives.map(({definitions})=>definitions))
+                var adjectiveKnots=definitions.filter(def=>def.knot).map(({knot})=>knot)
+                var adjectiveTies=definitions.filter(def=>def.tie).map(({tie})=>tie)
+                if (adjectiveKnots.length>0)
+                {
+                    act.subject=act.subject.join(...adjectiveKnots)    
+                }
+                if (adjectiveTies.length>0)
+                {
+                    act.subject=act.subject.hasPlies(...adjectiveTies)
+                }
+            } 
+		var size=act.subject.size
+		if (size==0 )
+		{
+			// narrate there is no subject error 
+			return true
+		}
+		if (size > 1)
+		{
+			//narrate disambiguation
+			return true
+		}
+		
+        }
+	else
+	{
+		act.subject=this.yarn.net["player"]
+	}
+	if (verb)
+	{
+		
+		//DEFECT:  Plot needs join, union, disjoin, etc.
+		act.verb=ISHML.Plot(this.yarn).add(...verb.definitions.map(({plotpoint})=>plotpoint))
+		/*if (indirectObject.preposition)
+		{
+			act.verb.join(...indirectObject.preposition.defintions.map(({plotpoint})=>plotpoint))
+		}
+		var size=act.verb.size
+		if (size==0 )
+		{
+			// narrate there is no verb error
+			return true
+		}
+		if (size > 1)
+		{
+			//narrate disambiguation
+			return true
+		}*/
+	}
+	if (directObject)
+        {
+            act.directObject=ISHML.Mesh(this.yarn).add(...directObject.nounPhrase.noun.definitions.map(({knot})=>knot))
+            
+            var adjectives=directObject.nounPhrase.adjectives
+            if(adjectives)
+            {
+
+                var definitions=[].concat([],...adjectives.map(({definitions})=>definitions))
+                var adjectiveKnots=definitions.filter(def=>def.knot).map(({knot})=>knot)
+                var adjectiveTies=definitions.filter(def=>def.tie).map(({tie})=>tie)
+                if (adjectiveKnots.length>0)
+                {
+                    act.directObject=act.directObject.join(...adjectiveKnots)    
+                }
+                if (adjectiveTies.length>0)
+                {
+                    act.directObject=act.directObject.hasPlies(...adjectiveTies)
+                }
+            } 
+		var size=act.directObject.size
+		if (size==0 )
+		{
+			// narrate there is no object error 
+			return true
+		}
+		if (size > 1)
+		{
+			//narrate disambiguation
+			return true
+		}
+        }
+	if (indirectObject)
+        {
+            act.indirectObject=ISHML.Mesh(this.yarn).add(...indirectObject.nounPhrase.noun.definitions.map(({knot})=>knot))
+            
+            var adjectives=indirectObject.nounPhrase.adjectives
+            if(adjectives)
+            {
+
+                var definitions=[].concat([],...adjectives.map(({definitions})=>definitions))
+                var adjectiveKnots=definitions.filter(def=>def.knot).map(({knot})=>knot)
+                var adjectiveTies=definitions.filter(def=>def.tie).map(({tie})=>tie)
+                if (adjectiveKnots.length>0)
+                {
+                    act.indirectObject=act.indirectObject.join(...adjectiveKnots)    
+                }
+                if (adjectiveTies.length>0)
+                {
+                    act.indirectObject=act.indirectObject.hasPlies(...adjectiveTies)
+                }
+            }
+		var size=act.indirectObject.size
+		if (size==0 )
+		{
+			// narrate there is no object error 
+			return true
+		}
+		if (size > 1)
+		{
+			//narrate disambiguation
+			return true
+		}
+		
+        }
+
+    act.agent=story.net[agent]
+	this.yarn.storyline.introduce(this.yarn.plot.act,{act:act})
+
+	return true
+        //return this.plot["act"].narrate({command:command})
+        
+    }
+    else return false
+}
+plot.act.narrate=function(twist)
+{
+	console.log("act")
+	var {act}=twist
+	if (act)
+	{
+		return act.verb.narrate(act)
+	}
+}
+
+plot.action_go.narrate=function(twist)
+{
+	console.log("go")
+console.log(twist)	
+   
+    var {subject,verb,directObject,indirectObject}=twist
+	if (directObject)
+	{
+        directObject=directObject.labeled("room")
+        if(directObject.size===1)
+        {    
+    		[directObject]=directObject.toArray()	
+    	    story.say
+    	    (
+    		`<p>${subject.name} decide to go to the ${directObject.name}.</p>`
+    	    ).last("div#story")
+		}
+        //DEFECT: need to ask the room if this is OK
+        //DEFECT: need to ask the subject if this is OK
+        /*
+            this.where().do()
+                .where().do()
+        */
+        story.net.player
+            .untie("in").from(directObject)
+            .tie("in").to(directObject).conversely("contains")
+        story.say
+            (
+            `<p>${directObject.description}.</p>`
+            ).last("div#story")    
+       // this.yarn.storyline.introduce(this.yarn.plot.report,{location:story.net.player, agent:agent})
+    	return true
+	}
+    else
+    {
+        story.say
+            (
+            `<p>You cannot go to the ${directObject.name}, no matter how much you want to.</p>`
+            ).last("div#story") 
+    }
+}
+plot.action_north.narrate=function(twist)
+{
+    console.log("go north")
+console.log(twist)  
+    var {subject,verb,directObject,indirectObject,agent}=twist
+    if (directObject)
+    {
+        directObject=directObject.labeled("room")
+        if(directObject.size===1)
+        {    
+            [directObject]=directObject.toArray()   
+            story.say
+            (
+            `<p>${subject.$.name} decide to go to the ${directObject.$.name}.</p>
+            <p> ${directObject.description}`
+            ).last("div#story")
+        }
+        return true
+    }
+}
+plot.disambiguate.narrate=function(twist)
+{
+    var {interpretations}=twist||[]
+    if (interpretations.length>1)
+    { 
+        story.say
+        (
+        `<p>You think to yourself "${this.yarn.net.ISHML_input.text}", but that could mean more than one thing.  You should focus on what you want.</p>`
+        ).last("div#story")
+        console.log(interpretations)
+        return true
+    }    
+}
+plot.add("report_location")
+plot.report_location.narrate-function(twist)
+{
+    story.say
+        (
+        `<p>You are here.</p>`
+        ).last("div#story")
+       
+}
+
+var pb =ISHML.phrasebook
+story.say
+(   `<div id="story"></div>
+    <div><em>&gt;</em><input id="command" data-plot="parse" data-agent="player" data-grammar="input" class="ISHML-input"></input>`
+   
+        
+).first("body")
+// <a data-input="go bar" class="ISHML-choice">Bar</a> <span data-input="Go" class="ISHML-drag">Go</span></div>		
+//<div><input></input></div><div data-input="foyer" class="ISHML-drop">Foyer</div>`
+storyline.introduce(plot.parse,{input:{text:"go foyer",grammar:grammar.input,agent:"player"}})
+
+story.harken("#command")
+story.tell()
+story.plot.heed.narrate("Can you hear me now?")
+
+
+//storyline.heed("#command input")
+//storyline.interruption?
+//document.querySelector("div#command input").onkeyup=story.input.bind(story)
+//document.querySelector("div#command a").onclick=story.click.bind(story)
+
+	//to add plotpoints to story: story.plot.add("plotpoint 1").add("plotpoint 2")
+	//to add child plotpoints: story.plot(plotpoint_1.storyline.add("plotpoint 3").add("plotpoint 4"))
+
+//story.plot.add("introduction")
+//.storyline.plotpoint("choice 1","choice 2", "choice 3")
+//story.plotpoint("describe location").situation(player.location.plotline)
+//story.plotpoint("describe location").content(`you are here: ${player.location.OBJ.description}.`)
+
+/*
+
+"Cloak of Darkness" is a brief example game that has been implemented in nearly every IF system currently used. It hasn't got much claim to complexity or richness, but it does exemplify many of the standard things one might want an IF language to be able to do: define descriptions and the results of actions, assign synonyms to nouns, create new verbs, handle darkness, track repeated acts, and so on.
+
+Here is what the game looks like in Inform:
+
+"Cloak of Darkness"
+
+The story headline is "A basic IF demonstration."
+
+Use scoring.
+
+The maximum score is 2.
+
+Whatever room we define first becomes the starting room of the game, in the absence of other instructions:
+
+Foyer of the Opera House is a room. "You are standing in a spacious hall, splendidly decorated in red and gold, with glittering chandeliers overhead. The entrance from the street is to the north, and there are doorways south and west."
+
+Instead of going north in the Foyer, say "You've only just arrived, and besides, the weather outside seems to be getting worse."
+
+We can add more rooms by specifying their relation to the first room. Unless we say otherwise, the connection will automatically be bidirectional, so "The Cloakroom is west of the Foyer" will also mean "The Foyer is east of the Cloakroom":
+
+The Cloakroom is west of the Foyer. "The walls of this small room were clearly once lined with hooks, though now only one remains. The exit is a door to the east."
+
+In the Cloakroom is a supporter called the small brass hook. The hook is scenery. Understand "peg" as the hook.
+
+Inform will automatically understand any words in the object definition ("small", "brass", and "hook", in this case), but we can add extra synonyms with this sort of Understand command.
+
+The description of the hook is "It's just a small brass hook, [if something is on the hook]with [a list of things on the hook] hanging on it[otherwise]screwed to the wall[end if]."
+
+This description is general enough that, if we were to add other hangable items to the game, they would automatically be described correctly as well.
+
+The Bar is south of the Foyer. The printed name of the bar is "Foyer Bar". The Bar is dark. "The bar, much rougher than you'd have guessed after the opulence of the foyer to the north, is completely empty. There seems to be some sort of message scrawled in the sawdust on the floor."
+
+The scrawled message is scenery in the Bar. Understand "floor" or "sawdust" as the message.
+
+Neatness is a kind of value. The neatnesses are neat, scuffed, and trampled. The message has a neatness. The message is neat.
+
+We could if we wished use a number to indicate how many times the player has stepped on the message, but Inform also makes it easy to add descriptive properties of this sort, so that the code remains readable even when the reader does not know what "the number of the message" might mean.
+
+Instead of examining the message: 
+    increment score; 
+    say "The message, neatly marked in the sawdust, reads..."; 
+    end the story finally.
+
+This second rule takes precedence over the first one whenever the message is trampled. Inform automatically applies whichever rule is most specific:
+
+Instead of examining the trampled message: 
+    say "The message has been carelessly trampled, making it difficult to read. You can just distinguish the words..."; 
+    end the story saying "You have lost".
+
+This command advances the state of the message from neat to scuffed and from scuffed to trampled. We can define any kinds of value we like and advance or decrease them in this way:
+
+Instead of doing something other than going in the bar when in darkness: 
+    if the message is not trampled, now the neatness of the message is the neatness after the neatness of the message; 
+    say "In the dark? You could easily disturb something."
+
+Instead of going nowhere from the bar when in darkness: 
+    now the message is trampled; 
+    say "Blundering around in the dark isn't a good idea!"
+
+This defines an object which is worn at the start of play. Because we have said the player is wearing the item, Inform infers that it is clothing and can be taken off and put on again at will.
+
+The player wears a velvet cloak. The cloak can be hung or unhung. Understand "dark" or "black" or "satin" as the cloak. The description of the cloak is "A handsome cloak, of velvet trimmed with satin, and slightly splattered with raindrops. Its blackness is so deep that it almost seems to suck light from the room."
+
+Carry out taking the cloak: 
+    now the bar is dark.
+
+Carry out putting the unhung cloak on something in the cloakroom: 
+    now the cloak is hung; 
+    increment score.
+
+Carry out putting the cloak on something in the cloakroom: 
+    now the bar is lit.
+
+Carry out dropping the cloak in the cloakroom: 
+    now the bar is lit.
+
+Instead of dropping or putting the cloak on when the player is not in the cloakroom: 
+    say "This isn't the best place to leave a smart cloak lying around."
+
+When play begins: 
+    say "[paragraph break]Hurrying through the rainswept November night, you're glad to see the bright lights of the Opera House. It's surprising that there aren't more people about but, hey, what do you expect in a cheap demo game...?"
+
+Understand "hang [something preferably held] on [something]" as putting it on.
+
+Test me with "s / n / w / inventory / hang cloak on hook / e / s / read message".
+
+And that's all. As always, type TEST ME to watch the scenario play itself out.
+*/
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,10 +24,10 @@
     <div class="container mt-4" id="quickstart">
       <h1>Getting Started</h1>
       <p>Place the following script near the end of the HTML document, before the closing <code>&lt;/body&gt;</code> tag. Then add your own script below this script.</p>
-      <p><code>&lt;script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.0.3/src/ishml.js"&gt;&lt;/script&gt;</code></p>
+      <p><code>&lt;script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.1.0/src/ishml.js"&gt;&lt;/script&gt;</code></p>
       <p>The <a href="parsing.html">parsing tutorial</a> explains how to use the library. </P>
       <p>The <a href="api.html">API reference</a> documents all features.</p>
-      <p>Contact: I am @bikibird on <a href="https://intfiction.org/">https://intfiction.org/</a>. I'd love to hear about anything you build with ISHML.</p>
+      <p>Contact: I am @bikibird on <a href="https://intfiction.org">https://intfiction.org</a>. I'd love to hear about anything you build with ISHML.</p>
     </div>
   </section>
 

--- a/docs/parsing.html
+++ b/docs/parsing.html
@@ -289,7 +289,7 @@ var example5 = parser.analyze("Take the really pretty ruby slipper.",{separator:
 </body>
 
 <script src="/whitewhale.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.0.3/src/ishml.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.1.0/src/ishml.js"></script>
 <script src="/parsingCodeListing.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/docs/parsing2.html
+++ b/docs/parsing2.html
@@ -52,41 +52,29 @@ nounPhrase.semantics=(interpretation)=>
 
 var command=ISHML.Rule()
 
-command.snip("subject",nounPhrase).snip("verb").snip("object")
+command.snip("subject",nounPhrase.clone()).snip("verb").snip("object")
 command.subject.configure({minimum:0})
 command.verb.configure({filter:(definition)=>definition.part==="verb"})
 command.object.configure({minimum:0,mode:ISHML.enum.mode.any})
     .snip(1)
     .snip(2)
 
-command.object[1].snip("directObject",nounPhrase).snip("indirectObject")
-command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase)
+command.object[1].snip("directObject",nounPhrase.clone()).snip("indirectObject")
+command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase.clone())
 command.object[1].indirectObject
     .configure({minimum:0})
 command.object[1].indirectObject.preposition
     .configure({filter:(definition)=>definition.part==="preposition"})
 
-command.object[2].snip("indirectObject",nounPhrase).snip("directObject",nounPhrase)
+command.object[2].snip("indirectObject",nounPhrase.clone()).snip("directObject",nounPhrase.clone())
 
 command.semantics=(interpretation)=>
 {
     var {gist}=interpretation
-    var prepositions=new Set(gist.verb.prepositions)
     if (gist.object)
     {
         if(gist.object.indirectObject)
         {
-            if (gist.object.indirectObject.preposition)
-            {
-                if (!prepositions.has(gist.object.indirectObject.preposition))
-                {
-                    return false 
-                }
-                else
-                {
-                    gist.verb.prepositions=[gist.object.indirectObject.preposition]
-                }
-            }
             gist.indirectObject=gist.object.indirectObject.nounPhrase
         }
         gist.directObject=gist.object.directObject.nounPhrase
@@ -98,7 +86,8 @@ command.semantics=(interpretation)=>
             <h2>Rule Cloning</h2>
             <p>Refer to Code Listing 1. First, we create the <code>nounPhrase</code> rule that we can re-use in the <code>subject</code>, <code>directObject</code>, and <code>indirectObject</code> rules.  You should recognize the code for the <code>nounPhrase</code> rule from <a href="parsing.html">part one</a>.</p>
             <p>(The version of <code>nounPhrase</code> shown here also defines a  <code>.semantics</code> property, which will be explained toward the end of this tutorial.)</p>
-            <p>Now that we have a <code>nounPhrase rule</code>, let's put it to work in our root rule, <code>command</code>.  We use <code>.snip()</code> to create sub-rules, <code>subject</code>, <code>verb</code> and <code>object</code>. The <code>verb</code> rule is defined just as it was in <a href="parsing.html">part one</a>. However, the <code>subject</code> rule is created by passing in <code>nounPhrase</code> as the second argument of <code>.snip()</code>. This creates a deep copy of <code>nounPhrase</code> as the <code>subject</code> rule.  Similarly, <code>nounPhrase</code> appears as a sub-rule of <code>indirectObject</code> and <code>directObject</code>.  In both cases, they are entirely new instances of <code>ISHML.Rule</code>, which are identical to the original <code>nounPhrase</code> rule. Any subsequent changes to the orginal <code>nounPhrase</code> rule will not affect the cloned rules. Conversely, changes to the cloned rules will not affect the original rule.</p>
+            <p>Now that we have a <code>nounPhrase rule</code>, let's put it to work in our root rule, <code>command</code>.  We use <code>.snip()</code> to create sub-rules, <code>subject</code>, <code>verb</code> and <code>object</code>. The <code>verb</code> rule is defined just as it was in <a href="parsing.html">part one</a>. However, the <code>subject</code> rule is created by passing in <code>nounPhrase.clone()</code> as the second argument of <code>.snip()</code>. This creates a deep copy of <code>nounPhrase</code> as the <code>subject</code> rule.  Similarly, <code>nounPhrase</code> appears as a sub-rule of <code>indirectObject</code> and <code>directObject</code>.  In both cases, they are entirely new instances of <code>ISHML.Rule</code> because of the use of <code>.clone()</code>. They are identical copies of the original <code>nounPhrase</code> rule. Any subsequent changes to the orginal <code>nounPhrase</code> rule will not affect the cloned rules. Conversely, changes to the cloned rules will not affect the original rule.</p>
+            <p>(It should be noted that it is sometimes useful to recursively define a rule by referencing itself. In that case <code>.clone()</code> is not used. This advanced use of rules will be covered in a future tutorial.)</p>
             <h2>Choice Rules</h2>
             <p>By default all sub-rules created with <code>.snip()</code> are treated as a sequence of snippets when parsed. In the resulting syntax tree, all the snippets are child nodes of the parent node.  However, we can change the mode that the parent rule operates under so that it treats the sub-rules as alternatives to choose among instead of a sequence.</p>
             <p>The <code>object</code> rule is configured with the <code>mode</code> option set to <code>ISHML.enum.mode.any</code>, which means that the sub-rules of <code>object</code> are treated as alternative choices.  Next, we <code>.snip()</code> two sub-rules, which we call <code>1</code> and <code>2</code>. By convention, we list each <code>.snip()</code> on a separate line to visually cue that they are choice sub-rules, not sequence sub-rules.</p>
@@ -118,7 +107,7 @@ command.semantics=(interpretation)=>
 </body>
 
 <script src="/whitewhale.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.0.3/src/ishml.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.1.0/src/ishml.js"></script>
 <script src="/parsing2CodeListing.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/docs/parsing2CodeListing.js
+++ b/docs/parsing2CodeListing.js
@@ -30,41 +30,29 @@ nounPhrase.semantics=(interpretation)=>
 
 var command=ISHML.Rule()
 
-command.snip("subject",nounPhrase).snip("verb").snip("object")
+command.snip("subject",nounPhrase.clone()).snip("verb").snip("object")
 command.subject.configure({minimum:0})
 command.verb.configure({filter:(definition)=>definition.part==="verb"})
 command.object.configure({minimum:0,mode:ISHML.enum.mode.any})
     .snip(1)
     .snip(2)
 
-command.object[1].snip("directObject",nounPhrase).snip("indirectObject")
-command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase)
+command.object[1].snip("directObject",nounPhrase.clone()).snip("indirectObject")
+command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase.clone())
 command.object[1].indirectObject
     .configure({minimum:0})
 command.object[1].indirectObject.preposition
     .configure({filter:(definition)=>definition.part==="preposition"})
 
-command.object[2].snip("indirectObject",nounPhrase).snip("directObject",nounPhrase)
+command.object[2].snip("indirectObject",nounPhrase.clone()).snip("directObject",nounPhrase.clone())
 
 command.semantics=(interpretation)=>
 {
     var {gist}=interpretation
-    var prepositions=new Set(gist.verb.prepositions)
     if (gist.object)
     {
         if(gist.object.indirectObject)
         {
-            if (gist.object.indirectObject.preposition)
-            {
-                if (!prepositions.has(gist.object.indirectObject.preposition))
-                {
-                    return false 
-                }
-                else
-                {
-                    gist.verb.prepositions=[gist.object.indirectObject.preposition]
-                }
-            }
             gist.indirectObject=gist.object.indirectObject.nounPhrase
         }
         gist.directObject=gist.object.directObject.nounPhrase

--- a/examples/test.html
+++ b/examples/test.html
@@ -2,64 +2,80 @@
     <head>
     </head>
     <body>
-        <!--<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.0.0/src/ishml.js"></script>-->
+        <!--<script src="https://cdn.jsdelivr.net/gh/bikibird/ishml@1.1.0/src/ishml.js"></script>-->
         <script src="../src/ishml.js"></script>
         <script>
-            var lexicon=ISHML.Lexicon()
-            lexicon
-                .register("the","a","an").as({part:"article"})
-                .register("take").as({key:"take",part:"verb"})
-                .register("steal").as({key:"take",part:"verb"})
-                .register("grab").as({key:"take",part:"verb"})
-                .register("drop").as({key:"drop",part:"verb"})
-                .register("leave").as({key:"drop",part:"verb"})
-                .register("ring").as({key:"ring",part:"noun", role:"thing"})
-                .register("slipper").as({key:"slipper",part:"noun", role:"thing"})
-                .register("diamond").as({key:"ring",part:"adjective", role:"thing"})
-                .register("diamond jim").as({key:"jim",part:"noun", role:"npc"})
-                .register("jim").as({key:"james",part:"noun", role:"npc"})
-                .register("ruby").as({key:"ring",part:"adjective", role:"thing"})
-                .register("ruby").as({key:"ruby",part:"noun", role:"thing"})
-                .register("ruby").as({key:"slipper",part:"adjective", role:"thing"})
-                .register("glass").as({key:"slipper",part:"adjective", role:"thing"})
-                .register("glass").as({key:"tumbler",part:"noun", role:"thing"})
-                .register("looking glass").as({key:"mirror",part:"noun", role:"thing"})
-                .register("good looking").as({key:"tumbler",part:"adjective", role:"thing"})
-                .register("good").as({key:"mirror",part:"adjective", role:"thing"})
-                .register("tumbler").as({key:"tumbler",part:"noun", role:"thing"})
-                .register("ruby").as({key:"miss_ruby",part:"noun", role:"npc"})
-                .register("sam").as({key:"sam",part:"noun", role:"npc"})
-                .register("from").as({key:"from",part:"preposition"})
-                .register("to").as({key:"to",part:"preposition"})
-            
-            var nounPhrase=ISHML.Rule()
-            
-            nounPhrase
-                .snip("article").snip("adjectives").snip("noun")
-                
-            nounPhrase.article
-                .configure({minimum:0, filter:(definition)=>definition.part==="article" })
-            nounPhrase.adjectives
-                .configure(
-                    {   minimum:0, maximum:Infinity, 
-                        filter:(definition)=>definition.part==="adjective"
-                    })
-            nounPhrase.noun.configure({filter:(definition)=>definition.part==="noun" })     
-            
-            var command=ISHML.Rule()
-                command.snip("subject",nounPhrase).snip("verb").snip("object")
-                command.subject.configure({minimum:0})
-                command.verb.configure({filter:(definition)=>definition.part==="verb"})
-                command.object.configure({minimum:0,mode:ISHML.enum.mode.any})
-                    .snip(1)
-                    .snip(2)
-                command.object[1].snip("directObject",nounPhrase).snip("indirectObject")
-                command.object[1].indirectObject.configure({minimum:0})
-                command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase)
-                command.object[1].indirectObject.preposition.configure({filter:(definition)=>definition.part==="preposition"})
-                command.object[2].snip("indirectObject",nounPhrase).snip("directObject",nounPhrase)
- 
-            var parser=ISHML.Parser({lexicon:lexicon,grammar:command})    
+var lexicon = ISHML.Lexicon()
+lexicon
+    .register("the", "a", "an").as({ part: "article" })
+    .register("take", "steal", "grab")
+        .as({ key: "take", part: "verb", prepositions: ["to", "from"] })
+    .register("drop", "leave").as({ key: "drop", part: "verb", prepositions: [] })
+    .register("ring").as({ key: "ring", part: "noun", role: "thing" })
+    .register("slipper").as({ key: "slipper", part: "noun", role: "thing" })
+    .register("diamond").as({ key: "ring", part: "adjective", role: "thing" })
+    .register("diamond jim").as({ key: "jim", part: "noun", role: "npc" })
+    .register("jim").as({ key: "james", part: "noun", role: "npc" })
+    .register("ruby").as({ key: "ring", part: "adjective", role: "thing" })
+    .register("ruby").as({ key: "ruby", part: "noun", role: "thing" })
+    .register("ruby").as({ key: "slipper", part: "adjective", role: "thing" })
+    .register("glass").as({ key: "slipper", part: "adjective", role: "thing" })
+    .register("glass").as({ key: "tumbler", part: "noun", role: "thing" })
+    .register("looking glass").as({ key: "mirror", part: "noun", role: "thing" })
+    .register("good looking").as({ key: "tumbler", part: "adjective", role: "thing" })
+    .register("good").as({ key: "mirror", part: "adjective", role: "thing" })
+    .register("tumbler").as({ key: "tumbler", part: "noun", role: "thing" })
+    .register("ruby").as({ key: "miss_ruby", part: "noun", role: "npc" })
+    .register("sam").as({ key: "sam", part: "noun", role: "npc" })
+    .register("from").as({ key: "from", part: "preposition" })
+    .register("to").as({ key: "to", part: "preposition" })
+
+    var adjNoun=ISHML.Rule()
+
+adjNoun
+    .snip("article").snip("adjectives").snip("noun")
+
+adjNoun.article
+    .configure({minimum:0, filter:(definition)=>definition.part==="article" })
+adjNoun.adjectives
+    .configure(
+    { minimum:0, maximum:Infinity,
+            filter:(definition)=>definition.part==="adjective"
+    })
+
+    adjNoun.noun.configure({filter:(definition)=>definition.part==="noun" })
+
+    var nounPhrase=ISHML.Rule()
+    
+nounPhrase.snip("NP", adjNoun).snip("relation")
+  //  nounPhrase.relation.snip("preposition").snip("RNP",adjNoun)
+
+// Would like above to be:
+ nounPhrase.relation.snip("preposition").snip("RNP",nounPhrase)
+
+nounPhrase.relation.configure({minimum:0})
+nounPhrase.relation.preposition
+    .configure({filter:(definition)=>definition.part==="preposition"})
+
+
+var command=ISHML.Rule()
+
+command.snip("subject",nounPhrase).snip("verb").snip("object")
+command.subject.configure({minimum:0})
+command.verb.configure({filter:(definition)=>definition.part==="verb"})
+command.object.configure({minimum:0,mode:ISHML.enum.mode.any})
+    .snip(1)
+    .snip(2)
+
+command.object[1].snip("directObject",nounPhrase).snip("indirectObject")
+command.object[1].indirectObject.snip("preposition").snip("nounPhrase",nounPhrase)
+command.object[1].indirectObject.configure({minimum:0})
+command.object[1].indirectObject.preposition
+    .configure({filter:(definition)=>definition.part==="preposition"})
+
+    command.object[2].snip("indirectObject",nounPhrase).snip("directObject",nounPhrase)
+
+    var parser=ISHML.Parser({lexicon:lexicon,grammar:command})    
 /*
     parser.analyze("take ruby glass slipper")
     parser.analyze("take ruby glass slipper to ruby")

--- a/src/ishml-lp.js
+++ b/src/ishml-lp.js
@@ -616,7 +616,7 @@ ISHML.Rule.prototype.snip =function(key,rule)
 
 	if (rule instanceof ISHML.Rule)
 	{
-		this[formattedKey]=rule.clone()
+		this[formattedKey]=rule
 	}
 	else
 	{

--- a/src/ishml.js
+++ b/src/ishml.js
@@ -616,7 +616,7 @@ ISHML.Rule.prototype.snip =function(key,rule)
 
 	if (rule instanceof ISHML.Rule)
 	{
-		this[formattedKey]=rule.clone()
+		this[formattedKey]=rule
 	}
 	else
 	{

--- a/src/rule.js
+++ b/src/rule.js
@@ -278,7 +278,7 @@ ISHML.Rule.prototype.snip =function(key,rule)
 
 	if (rule instanceof ISHML.Rule)
 	{
-		this[formattedKey]=rule.clone()
+		this[formattedKey]=rule
 	}
 	else
 	{


### PR DESCRIPTION
Use .clone() to explicitly clone a rule.